### PR TITLE
Add 5.11.X compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,27 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.avisi.bamboo.plugins</groupId>
     <artifactId>elm-for-bamboo</artifactId>
     <version>1.0.0</version>
-
     <organization>
         <name>Avisi BV</name>
         <url>https://www.avisi.nl/</url>
     </organization>
-
     <name>Elm for Bamboo</name>
     <description>Add Elm tasks to Bamboo</description>
     <packaging>atlassian-plugin</packaging>
-
     <properties>
-        <bamboo.version>5.14.1</bamboo.version>
+        <bamboo.version>5.11.0</bamboo.version>
         <bamboo.data.version>5.8.1</bamboo.data.version>
-        <amps.version>6.2.6</amps.version>
+        <amps.version>6.2.11</amps.version>
         <java.version>1.8</java.version>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.atlassian.bamboo</groupId>
@@ -49,7 +45,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -62,7 +57,6 @@
                     <productDataVersion>${bamboo.data.version}</productDataVersion>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -79,7 +73,21 @@
             </plugin>
         </plugins>
     </build>
-
+    <repositories>
+        <repository>
+            <id>atlassian-public</id>
+            <url>https://maven.atlassian.com/repository/public</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>warn</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
     <scm>
         <developerConnection>scm:git:ssh://git@github.com:avisi/elm-for-bamboo.git</developerConnection>
         <tag>HEAD</tag>

--- a/src/main/java/nl/avisi/bamboo/plugins/elmforbamboo/parser/TestOutputParser.java
+++ b/src/main/java/nl/avisi/bamboo/plugins/elmforbamboo/parser/TestOutputParser.java
@@ -42,7 +42,13 @@ public class TestOutputParser {
                     final String suiteName = name.substring(0, testNameIndex);
                     final String testName = name.substring(testNameIndex + 1);
 
-                    TestResults testResults = new TestResults(suiteName, testName, Long.parseLong(event.getDuration()));
+                    //Deprecated method is used to comply with bamboo 5.11
+                    TestResults testResults = new TestResults(
+                            suiteName,
+                            testName,
+                            String.valueOf(Long.parseLong(event.getDuration()) / 1000)
+                    );
+
                     if ("pass".equals(event.getStatus())) {
                         testResults.setState(TestState.SUCCESS);
                         successfulTestResults.add(testResults);


### PR DESCRIPTION
* Add repository to Atlassian.
* Use deprecated call to TestResults (divide millis by 1000 to get to seconds).
* Bump APMS version